### PR TITLE
Improve pubkey not found error handling

### DIFF
--- a/src/jwtf.erl
+++ b/src/jwtf.erl
@@ -175,12 +175,7 @@ key(Props, Checks, KS) ->
         {true, undefined} ->
             throw({error, missing_kid});
         {_, KID} ->
-            case KS(Alg, KID) of
-                {error, Reason} ->
-                    throw({error, {key, {Alg, KID}, Reason}});
-                Key ->
-                    Key
-            end
+            KS(Alg, KID)
     end.
 
 
@@ -369,8 +364,8 @@ public_key_not_found_test() ->
     Encoded = encode(
         {[{<<"alg">>, <<"RS256">>}, {<<"kid">>, <<"1">>}]},
         {[]}),
-    KS = fun(_, _) -> {error, not_found} end,
-    Expected = {error, {key, {<<"RS256">>, <<"1">>}, not_found}},
+    KS = fun(_, _) -> throw({error, not_found}) end,
+    Expected = {error, not_found},
     ?assertEqual(Expected, decode(Encoded, [], KS)).
 
 


### PR DESCRIPTION
When the public key identified by the `{Alg, KID}` tuple is not found on
the IAM keystore server, it's possible to see errors like:
```
(node1@127.0.0.1)140> epep:jwt_decode(SampleJWT).
** exception error: no function clause matching
                    public_key:do_verify(<<"eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsImtpZCI6IjIwMTcwNTIwLTAwOjAwOjAwIn0.eyJpc3MiOiJodHRwOi8vbG9jYWxob3N0OjEyMzIx"...>>,
                                         sha256,
                                         <<229,188,162,247,201,233,118,32,115,206,156,
                                           169,17,221,78,157,161,147,46,179,42,219,66,
                                           15,139,91,...>>,
                                         {error,not_found}) (public_key.erl, line 782)
     in function  jwtf:public_key_verify/4 (src/jwtf.erl, line 212)
     in call from jwtf:decode/3 (src/jwtf.erl, line 30)
```
Where the tuple `{error, not_found}` gets passed to the
public_key:do_verify function instead of being caught as soon as KS
returns an error.

This change throws the appropriate error message if it matches an
error returned from KS.