### PR TITLE
Handle malformed tokens with jiffy 1.x

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -1,0 +1,2 @@
+{cover_enabled, true}.
+{cover_print_enabled, true}.

--- a/test/jwtf_tests.erl
+++ b/test/jwtf_tests.erl
@@ -35,6 +35,30 @@ jwt_io_pubkey() ->
     public_key:pem_entry_decode(PEMEntry).
 
 
+b64_badarg_test() ->
+    Encoded = <<"0.0.0">>,
+    ?assertEqual({error, {bad_request,badarg}},
+        jwtf:decode(Encoded, [], nil)).
+
+
+b64_bad_block_test() ->
+    Encoded = <<" aGVsbG8. aGVsbG8. aGVsbG8">>,
+    ?assertEqual({error, {bad_request,{bad_block,0}}},
+        jwtf:decode(Encoded, [], nil)).
+
+
+invalid_json_test() ->
+    Encoded = <<"fQ.fQ.fQ">>,
+    ?assertEqual({error, {bad_request,{1,invalid_json}}},
+        jwtf:decode(Encoded, [], nil)).
+
+
+truncated_json_test() ->
+    Encoded = <<"ew.ew.ew">>,
+    ?assertEqual({error, {bad_request,{2,truncated_json}}},
+        jwtf:decode(Encoded, [], nil)).
+
+
 missing_typ_test() ->
     Encoded = encode({[]}, []),
     ?assertEqual({error, {bad_request,<<"Missing typ header parameter">>}},


### PR DESCRIPTION
Recent changes in how `jiffy:decode/1` handles malformed JSON has caused
`jwtf:decode/3` to fail to properly return a bad request 400 response
for some malformed tokens.

First, this changes the name of the function to `decode_b64url_json/1`,
indicating that it decodes something that has been first been JSON
encoded, and then base64 encoded.

More substantially, it wraps both the base64url and jiffy decoding in a
try/catch block, since both can throw errors, while the former can also
return an error tuple. Tests have been added to ensure all code paths
are covered.
